### PR TITLE
fix: remove unused `requirements-dev.txt`

### DIFF
--- a/tests/requirements-dev.txt
+++ b/tests/requirements-dev.txt
@@ -1,8 +1,0 @@
-attrs==22.2.0
-coverage==7.0.1
-exceptiongroup==1.1.0
-iniconfig==1.1.1
-packaging==22.0
-pluggy==1.0.0
-pytest==7.2.0
-tomli==2.0.1


### PR DESCRIPTION
No longer needed since project has been migrated to `uv`.